### PR TITLE
Update erlang_nif-sys for compatibility

### DIFF
--- a/native/exgpgme/Cargo.lock
+++ b/native/exgpgme/Cargo.lock
@@ -1,13 +1,3 @@
-[root]
-name = "exgpgme"
-version = "0.1.0"
-dependencies = [
- "gpgme 0.6.1 (git+https://github.com/johnschug/rust-gpgme.git)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustler 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustler_codegen 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "bitflags"
 version = "0.9.1"
@@ -33,10 +23,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "erlang_nif-sys"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "exgpgme"
+version = "0.1.0"
+dependencies = [
+ "gpgme 0.6.1 (git+https://github.com/johnschug/rust-gpgme.git)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustler 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustler_codegen 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -110,7 +110,7 @@ name = "rustler"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "erlang_nif-sys 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "erlang_nif-sys 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -164,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
-"checksum erlang_nif-sys 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2804cb6ae339787d993faafdd5e4af5a882128e44343a710d1061c487086eaa3"
+"checksum erlang_nif-sys 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9bc72dbc2c220693a2a009ec97705c144ea5cc5db703df43feb903663c999536"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum gpg-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c732e7f1b15b2e2a3c8be3ccdc8d645d3c22628901252318931fa54c1e13e08f"
 "checksum gpgme 0.6.1 (git+https://github.com/johnschug/rust-gpgme.git)" = "<none>"


### PR DESCRIPTION
Couldn't build the package as I was getting an error about unsupported erlang versions, but this fixed it for me. Running Erlang/OTP 21 [erts-10.1.3] / Elixir 1.7.3